### PR TITLE
Use pre-computed distances in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,29 @@
 
 ## BUGFIXES -->
 
+# dimensionality_reduction 0.2.0 2024-12-09
+
+## NEW FUNCTIONALITY
+
+* Add calculation of distances to/between waypoints and label centroids to dataset pre-processing
+* Add a post-processing component that calculates distances in the embedding space
+* Add to centroid and between label distance correlation scores
+
+## MAJOR CHANGES
+
+* Modify co-ranking metrics to use pre-computed distances
+* Modify distance correlation metrics to use pre-computed distances
+* Move spectral distance correlation to a separate component
+* Disable the trustworthiness metric as it is calculated as part of the co-ranking metrics
+
+## DOCUMENTATION
+
+* Update documentation for distance correlation metrics
+
+## MINOR CHANGES
+
+* Speed up calculating distance matrices in the co-ranking metrics (PR #4)
+
 # dimensionality_reduction 0.1.3 2024-10-09
 
 ## MINOR CHANGES

--- a/README.md
+++ b/README.md
@@ -66,16 +66,18 @@ recommended by the method.
 ## API
 
 ``` mermaid
-flowchart LR
-  file_common_dataset("Dataset")
-  comp_process_dataset[/"Data processor"/]
-  file_dataset("Dataset")
-  file_solution("Solution data")
-  comp_control_method[/"Control method"/]
-  comp_method[/"Method"/]
-  comp_metric[/"Metric"/]
-  file_embedding("Embedding")
-  file_score("Score")
+flowchart TB
+  file_common_dataset("<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#file-format-dataset'>Dataset</a>")
+  comp_process_dataset[/"<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#component-type-data-processor'>Data processor</a>"/]
+  file_dataset("<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#file-format-dataset'>Dataset</a>")
+  file_solution("<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#file-format-solution-data'>Solution data</a>")
+  comp_control_method[/"<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#component-type-control-method'>Control method</a>"/]
+  comp_method[/"<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#component-type-method'>Method</a>"/]
+  comp_metric[/"<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#component-type-metric'>Metric</a>"/]
+  comp_process_embedding[/"<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#component-type-data-processor'>Data processor</a>"/]
+  file_embedding("<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#file-format-embedding'>Embedding</a>")
+  file_score("<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#file-format-score'>Score</a>")
+  file_processed_embedding("<a href='https://github.com/openproblems-bio/task_dimensionality_reduction#file-format-embedding'>Embedding</a>")
   file_common_dataset---comp_process_dataset
   comp_process_dataset-->file_dataset
   comp_process_dataset-->file_solution
@@ -83,10 +85,13 @@ flowchart LR
   file_dataset---comp_method
   file_solution---comp_control_method
   file_solution---comp_metric
+  file_solution---comp_process_embedding
   comp_control_method-->file_embedding
   comp_method-->file_embedding
   comp_metric-->file_score
-  file_embedding---comp_metric
+  comp_process_embedding-->file_processed_embedding
+  file_embedding---comp_process_embedding
+  file_processed_embedding---comp_metric
 ```
 
 ## File format: Dataset
@@ -189,10 +194,11 @@ Format:
 <div class="small">
 
     AnnData object
-     obs: 'cell_type'
+     obs: 'cell_type', 'is_waypoint'
      var: 'hvg_score'
+     obsm: 'waypoint_distances', 'centroid_distances'
      layers: 'counts', 'normalized'
-     uns: 'dataset_id', 'dataset_name', 'dataset_url', 'dataset_reference', 'dataset_summary', 'dataset_description', 'dataset_organism', 'normalization_id'
+     uns: 'dataset_id', 'dataset_name', 'dataset_url', 'dataset_reference', 'dataset_summary', 'dataset_description', 'dataset_organism', 'normalization_id', 'between_waypoint_distances', 'label_centroids', 'between_centroid_distances'
 
 </div>
 
@@ -202,8 +208,11 @@ Data structure:
 
 | Slot | Type | Description |
 |:---|:---|:---|
-| `obs["cell_type"]` | `string` | Classification of the cell type based on its characteristics and function within the tissue or organism. |
+| `obs["cell_type"]` | `string` | Ground truth cell type based on a cells characteristics and function within the tissue or organism. |
+| `obs["is_waypoint"]` | `boolean` | Whether or not this cell is a waypoint used for some metric calculations. |
 | `var["hvg_score"]` | `double` | High variability gene score (normalized dispersion). The greater, the more variable. |
+| `obsm["waypoint_distances"]` | `double` | Euclidean distances between all cells and waypoint cells calculated using normalized data. |
+| `obsm["centroid_distances"]` | `double` | Euclidean distances between all cells and label centroids calculated using normalized data. |
 | `layers["counts"]` | `integer` | Raw counts. |
 | `layers["normalized"]` | `double` | Normalized expression values. |
 | `uns["dataset_id"]` | `string` | A unique identifier for the dataset. |
@@ -214,6 +223,9 @@ Data structure:
 | `uns["dataset_description"]` | `string` | Long description of the dataset. |
 | `uns["dataset_organism"]` | `string` | (*Optional*) The organism of the sample in the dataset. |
 | `uns["normalization_id"]` | `string` | Which normalization was used. |
+| `uns["between_waypoint_distances"]` | `double` | Euclidean distances between waypoint cells. |
+| `uns["label_centroids"]` | `double` | Centroid positions of each label in the normalized expression space. |
+| `uns["between_centroid_distances"]` | `double` | Euclidean distances between label centroids. |
 
 </div>
 
@@ -258,9 +270,25 @@ Arguments:
 
 | Name | Type | Description |
 |:---|:---|:---|
-| `--input_embedding` | `file` | A dataset with dimensionality reduction embedding. |
+| `--input_embedding` | `file` | A dataset with dimensionality reduction embedding that has been processed to add information required by metrics. |
 | `--input_solution` | `file` | The data for evaluating a dimensionality reduction. |
 | `--output` | `file` | (*Output*) Metric score file. |
+
+</div>
+
+## Component type: Data processor
+
+A dimensionality reduction embedding processor.
+
+Arguments:
+
+<div class="small">
+
+| Name | Type | Description |
+|:---|:---|:---|
+| `--input_embedding` | `file` | A dataset with dimensionality reduction embedding. |
+| `--input_solution` | `file` | The data for evaluating a dimensionality reduction. |
+| `--output` | `file` | (*Output*) A dataset with dimensionality reduction embedding that has been processed to add information required by metrics. |
 
 </div>
 
@@ -321,6 +349,42 @@ Data structure:
 | `uns["method_id"]` | `string` | A unique identifier for the method. |
 | `uns["metric_ids"]` | `string` | One or more unique metric identifiers. |
 | `uns["metric_values"]` | `double` | The metric values obtained for the given prediction. Must be of same length as ‘metric_ids’. |
+
+</div>
+
+## File format: Embedding
+
+A dataset with dimensionality reduction embedding that has been
+processed to add information required by metrics.
+
+Example file:
+`resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/processed_embedding.h5ad`
+
+Format:
+
+<div class="small">
+
+    AnnData object
+     obsm: 'X_emb', 'waypoint_distances', 'centroid_distances'
+     uns: 'dataset_id', 'method_id', 'normalization_id', 'between_waypoint_distances', 'label_centroids', 'between_centroid_distances'
+
+</div>
+
+Data structure:
+
+<div class="small">
+
+| Slot | Type | Description |
+|:---|:---|:---|
+| `obsm["X_emb"]` | `double` | The dimensionally reduced embedding. |
+| `obsm["waypoint_distances"]` | `double` | Euclidean distances between all cells and waypoint cells calculated using the embedding. |
+| `obsm["centroid_distances"]` | `double` | Euclidean distances between all cells and label centroids calculated using the embedding. |
+| `uns["dataset_id"]` | `string` | A unique identifier for the dataset. |
+| `uns["method_id"]` | `string` | A unique identifier for the method. |
+| `uns["normalization_id"]` | `string` | Which normalization was used. |
+| `uns["between_waypoint_distances"]` | `double` | Euclidean distances between waypoint cells. |
+| `uns["label_centroids"]` | `double` | Centroid positions of each label in the normalized expression space. |
+| `uns["between_centroid_distances"]` | `double` | Euclidean distances between label centroids. |
 
 </div>
 

--- a/scripts/create_resources/test_resources.sh
+++ b/scripts/create_resources/test_resources.sh
@@ -13,21 +13,26 @@ DATASET_DIR=resources_test/task_dimensionality_reduction
 
 mkdir -p $DATASET_DIR
 
-# process dataset
-echo Running process_dataset
+# Process dataset
 viash run src/data_processors/process_dataset/config.vsh.yaml -- \
     --input $RAW_DATA/cxg_mouse_pancreas_atlas/dataset.h5ad \
     --output_dataset $DATASET_DIR/cxg_mouse_pancreas_atlas/dataset.h5ad \
     --output_solution $DATASET_DIR/cxg_mouse_pancreas_atlas/solution.h5ad
 
-# run one method
+# Run one method
 viash run src/methods/pca/config.vsh.yaml -- \
     --input $DATASET_DIR/cxg_mouse_pancreas_atlas/dataset.h5ad \
     --output $DATASET_DIR/cxg_mouse_pancreas_atlas/embedding.h5ad
 
-# run one metric
-viash run src/metrics/clustering_performance/config.vsh.yaml -- \
+# Process embedding
+viash run src/data_processors/process_embedding/config.vsh.yaml -- \
     --input_embedding $DATASET_DIR/cxg_mouse_pancreas_atlas/embedding.h5ad \
+    --input_solution $DATASET_DIR/cxg_mouse_pancreas_atlas/solution.h5ad \
+    --output $DATASET_DIR/cxg_mouse_pancreas_atlas/processed_embedding.h5ad
+
+# Run one metric
+viash run src/metrics/clustering_performance/config.vsh.yaml -- \
+    --input_embedding $DATASET_DIR/cxg_mouse_pancreas_atlas/processed_embedding.h5ad \
     --input_solution $DATASET_DIR/cxg_mouse_pancreas_atlas/solution.h5ad \
     --output $DATASET_DIR/cxg_mouse_pancreas_atlas/score.h5ad
 
@@ -39,6 +44,6 @@ HERE
 
 # only run this if you have access to the openproblems-data bucket
 aws s3 sync --profile op \
-  "resources_test/task_dimensionality_reduction" \
-   s3://openproblems-data/resources_test/task_dimensionality_reduction \
-  --delete --dryrun
+    "resources_test/task_dimensionality_reduction" \
+    s3://openproblems-data/resources_test/task_dimensionality_reduction \
+    --delete --dryrun

--- a/src/api/comp_metric.yaml
+++ b/src/api/comp_metric.yaml
@@ -9,7 +9,7 @@ info:
 arguments:
   - name: "--input_embedding"
     direction: input
-    __merge__: file_embedding.yaml
+    __merge__: file_processed_embedding.yaml
     required: true
   - name: "--input_solution"
     __merge__: file_solution.yaml

--- a/src/api/comp_process_embedding.yaml
+++ b/src/api/comp_process_embedding.yaml
@@ -1,0 +1,26 @@
+namespace: data_processors
+info:
+  type: process_embedding
+  type_info:
+    label: Data processor
+    summary: A dimensionality reduction embedding processor.
+    description: |
+      A component for processing output from a dimensionality reduction method.
+arguments:
+  - name: "--input_embedding"
+    __merge__: file_embedding.yaml
+    direction: input
+    required: true
+  - name: "--input_solution"
+    __merge__: file_solution.yaml
+    direction: input
+    required: true
+  - name: "--output"
+    __merge__: file_processed_embedding.yaml
+    direction: output
+    required: true
+test_resources:
+  - path: /resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/
+    dest: resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/
+  - type: python_script
+    path: /common/component_tests/run_and_check_output.py

--- a/src/api/file_processed_embedding.yaml
+++ b/src/api/file_processed_embedding.yaml
@@ -1,0 +1,44 @@
+type: file
+example: "resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/processed_embedding.h5ad"
+label: "Embedding"
+summary: |
+  A dataset with dimensionality reduction embedding that has been processed to
+  add information required by metrics.
+info:
+  format:
+    type: h5ad
+    obsm:
+      - type: double
+        name: X_emb
+        description: The dimensionally reduced embedding.
+        required: true
+      - type: double
+        name: waypoint_distances
+        description: Euclidean distances between all cells and waypoint cells calculated using the embedding.
+        required: true
+      - type: double
+        name: centroid_distances
+        description: Euclidean distances between all cells and label centroids calculated using the embedding.
+        required: true
+    uns:
+      - type: string
+        name: dataset_id
+        description: "A unique identifier for the dataset"
+        required: true
+      - type: string
+        name: method_id
+        description: "A unique identifier for the method"
+        required: true
+      - type: string
+        name: normalization_id
+        description: "Which normalization was used"
+        required: true
+      - name: between_waypoint_distances
+        type: double
+        description: Euclidean distances between waypoint cells.
+      - name: label_centroids
+        type: double
+        description: Centroid positions of each label in the normalized expression space.
+      - name: between_centroid_distances
+        type: double
+        description: Euclidean distances between label centroids.

--- a/src/api/file_solution.yaml
+++ b/src/api/file_solution.yaml
@@ -17,12 +17,25 @@ info:
     obs:
       - type: string
         name: cell_type
-        description: Classification of the cell type based on its characteristics and function within the tissue or organism.
+        description: Ground truth cell type based on a cells characteristics and function within the tissue or organism.
+        required: true
+      - type: boolean
+        name: is_waypoint
+        description: Whether or not this cell is a waypoint used for some metric calculations.
         required: true
     var:
       - type: double
         name: hvg_score
         description: High variability gene score (normalized dispersion). The greater, the more variable.
+        required: true
+    obsm:
+      - type: double
+        name: waypoint_distances
+        description: Euclidean distances between all cells and waypoint cells calculated using normalized data.
+        required: true
+      - type: double
+        name: centroid_distances
+        description: Euclidean distances between all cells and label centroids calculated using normalized data.
         required: true
     uns:
       - type: string
@@ -57,3 +70,6 @@ info:
         name: normalization_id
         description: "Which normalization was used"
         required: true
+      - name: label_centroids
+        type: double
+        description: Centroid positions of each label in the normalized expression space.

--- a/src/api/file_solution.yaml
+++ b/src/api/file_solution.yaml
@@ -70,6 +70,12 @@ info:
         name: normalization_id
         description: "Which normalization was used"
         required: true
+      - name: between_waypoint_distances
+        type: double
+        description: Euclidean distances between waypoint cells.
       - name: label_centroids
         type: double
         description: Centroid positions of each label in the normalized expression space.
+      - name: between_centroid_distances
+        type: double
+        description: Euclidean distances between label centroids.

--- a/src/data_processors/process_dataset/script.py
+++ b/src/data_processors/process_dataset/script.py
@@ -2,12 +2,14 @@ import sys
 
 import anndata as ad
 import openproblems as op
+import numpy as np
+from sklearn.metrics import pairwise_distances
 
 ## VIASH START
 par = {
     "input": "resources_test/common/cxg_mouse_pancreas_atlas/dataset.h5ad",
-    "output_dataset": "train.h5ad",
-    "output_solution": "test.h5ad",
+    "output_dataset": "dataset.h5ad",
+    "output_solution": "solution.h5ad",
 }
 meta = {
     "resources_dir": "target/executable/data_processors/process_dataset",
@@ -15,24 +17,65 @@ meta = {
 }
 ## VIASH END
 
-
 # import helper functions
 sys.path.append(meta["resources_dir"])
 from subset_h5ad_by_format import subset_h5ad_by_format
 
+print("====== Dataset processor ======", flush=True)
+
+print("\n>>> Reading processor config...", flush=True)
 config = op.project.read_viash_config(meta["config"])
 
-print(">> Load Data", flush=True)
+print("\n>>> Reading raw dataset...", flush=True)
 adata = ad.read_h5ad(par["input"])
+print(adata, flush=True)
 
-print(adata)
+print("\n>>> Selecting waypoint cells...", flush=True)
+if adata.n_obs < 10000:
+    waypoint_cells = adata.obs_names
+else:
+    np.random.seed(0)  # Try to get the same cells each time
+    waypoint_cells = np.random.choice(adata.obs_names, 10000, replace=False)
+adata.obs["is_waypoint"] = adata.obs_names.isin(waypoint_cells)
 
-print(">> Creating input data", flush=True)
+print("\n>>> Calculating waypoint distances...", flush=True)
+adata.obsm["waypoint_distances"] = pairwise_distances(
+    adata.layers["normalized"],
+    adata.layers["normalized"][adata.obs["is_waypoint"].values, :],
+    metric="euclidean",
+    n_jobs = -2
+)
+
+print("\n>>> Calculating label centroids...", flush=True)
+normalized_mat = adata.layers["normalized"].todense()
+labels = np.unique(adata.obs["cell_type"])
+centroids = np.zeros((len(labels), normalized_mat.shape[1]))
+for i, label in enumerate(labels):
+    is_label = adata.obs["cell_type"] == label
+    centroids[i, :] = np.mean(normalized_mat[is_label, :], axis=0)
+
+adata.uns["label_centroids"] = centroids
+
+print("\n>>> Calculating centroid distances...", flush=True)
+adata.obsm["centroid_distances"] = pairwise_distances(
+    adata.layers["normalized"],
+    centroids,
+    metric="euclidean",
+    n_jobs = -2
+)
+
+print("\n>>> Creating input data...", flush=True)
 output_dataset = subset_h5ad_by_format(adata, config, "output_dataset")
+print(output_dataset, flush=True)
 
-print(">> Creating solution data", flush=True)
+print("\n>>> Creating solution data...", flush=True)
 output_solution = subset_h5ad_by_format(adata, config, "output_solution")
+print(output_solution, flush=True)
 
-print(">> Writing data", flush=True)
+print("\n>>> Writing data files...", flush=True)
 output_dataset.write_h5ad(par["output_dataset"])
+print(f"Output dataset file: '{par['output_dataset']}'", flush=True)
 output_solution.write_h5ad(par["output_solution"])
+print(f"Output solution file: '{par['output_solution']}'", flush=True)
+
+print("\n>>> Done!", flush=True)

--- a/src/data_processors/process_dataset/script.py
+++ b/src/data_processors/process_dataset/script.py
@@ -38,13 +38,23 @@ else:
     waypoint_cells = np.random.choice(adata.obs_names, 10000, replace=False)
 adata.obs["is_waypoint"] = adata.obs_names.isin(waypoint_cells)
 
-print("\n>>> Calculating waypoint distances...", flush=True)
+print("\n>>> Calculating distances to waypoints...", flush=True)
 adata.obsm["waypoint_distances"] = pairwise_distances(
     adata.layers["normalized"],
     adata.layers["normalized"][adata.obs["is_waypoint"].values, :],
     metric="euclidean",
     n_jobs = -2
 )
+np.fill_diagonal(adata.obsm["waypoint_distances"], 0)
+
+print("\n>>> Calculating distances between waypoints...", flush=True)
+adata.uns["between_waypoint_distances"] = pairwise_distances(
+    adata.layers["normalized"][adata.obs["is_waypoint"].values, :],
+    adata.layers["normalized"][adata.obs["is_waypoint"].values, :],
+    metric="euclidean",
+    n_jobs = -2
+)
+np.fill_diagonal(adata.uns["between_waypoint_distances"], 0)
 
 print("\n>>> Calculating label centroids...", flush=True)
 normalized_mat = adata.layers["normalized"].todense()
@@ -56,13 +66,23 @@ for i, label in enumerate(labels):
 
 adata.uns["label_centroids"] = centroids
 
-print("\n>>> Calculating centroid distances...", flush=True)
+print("\n>>> Calculating distances to centroids...", flush=True)
 adata.obsm["centroid_distances"] = pairwise_distances(
     adata.layers["normalized"],
     centroids,
     metric="euclidean",
     n_jobs = -2
 )
+np.fill_diagonal(adata.obsm["centroid_distances"], 0)
+
+print("\n>>> Calculating distances between centroids...", flush=True)
+adata.uns["between_centroid_distances"] = pairwise_distances(
+    centroids,
+    centroids,
+    metric="euclidean",
+    n_jobs = -2
+)
+np.fill_diagonal(adata.uns["between_centroid_distances"], 0)
 
 print("\n>>> Creating input data...", flush=True)
 output_dataset = subset_h5ad_by_format(adata, config, "output_dataset")

--- a/src/data_processors/process_dataset/script.py
+++ b/src/data_processors/process_dataset/script.py
@@ -1,8 +1,8 @@
 import sys
 
 import anndata as ad
-import openproblems as op
 import numpy as np
+import openproblems as op
 from sklearn.metrics import pairwise_distances
 
 ## VIASH START
@@ -43,7 +43,7 @@ adata.obsm["waypoint_distances"] = pairwise_distances(
     adata.layers["normalized"],
     adata.layers["normalized"][adata.obs["is_waypoint"].values, :],
     metric="euclidean",
-    n_jobs = -2
+    n_jobs=-2,
 )
 np.fill_diagonal(adata.obsm["waypoint_distances"], 0)
 
@@ -52,7 +52,7 @@ adata.uns["between_waypoint_distances"] = pairwise_distances(
     adata.layers["normalized"][adata.obs["is_waypoint"].values, :],
     adata.layers["normalized"][adata.obs["is_waypoint"].values, :],
     metric="euclidean",
-    n_jobs = -2
+    n_jobs=-2,
 )
 np.fill_diagonal(adata.uns["between_waypoint_distances"], 0)
 
@@ -68,19 +68,13 @@ adata.uns["label_centroids"] = centroids
 
 print("\n>>> Calculating distances to centroids...", flush=True)
 adata.obsm["centroid_distances"] = pairwise_distances(
-    adata.layers["normalized"],
-    centroids,
-    metric="euclidean",
-    n_jobs = -2
+    adata.layers["normalized"], centroids, metric="euclidean", n_jobs=-2
 )
 np.fill_diagonal(adata.obsm["centroid_distances"], 0)
 
 print("\n>>> Calculating distances between centroids...", flush=True)
 adata.uns["between_centroid_distances"] = pairwise_distances(
-    centroids,
-    centroids,
-    metric="euclidean",
-    n_jobs = -2
+    centroids, centroids, metric="euclidean", n_jobs=-2
 )
 np.fill_diagonal(adata.uns["between_centroid_distances"], 0)
 

--- a/src/data_processors/process_embedding/config.vsh.yaml
+++ b/src/data_processors/process_embedding/config.vsh.yaml
@@ -1,0 +1,20 @@
+# Base component API configuration
+__merge__: /src/api/comp_process_embedding.yaml
+
+# Component configuration
+name: process_embedding
+
+# Script configuration
+resources:
+  - type: python_script
+    path: script.py
+
+# Platform configuration
+engines:
+  - type: docker
+    image: openproblems/base_python:1.0.0
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: [highmem, midcpu, midtime]

--- a/src/data_processors/process_embedding/script.py
+++ b/src/data_processors/process_embedding/script.py
@@ -22,13 +22,23 @@ adata = ad.read_h5ad(par["input_embedding"])
 adata = adata[solution.obs_names, :].copy()
 print(adata, flush=True)
 
-print("\n>>> Calculating waypoint distances...", flush=True)
+print("\n>>> Calculating distances to waypoints...", flush=True)
 adata.obsm["waypoint_distances"] = pairwise_distances(
     adata.obsm["X_emb"],
     adata.obsm["X_emb"][solution.obs["is_waypoint"].values, :],
     metric="euclidean",
     n_jobs=-2,
 )
+np.fill_diagonal(adata.obsm["waypoint_distances"], 0)
+
+print("\n>>> Calculating distances between waypoints...", flush=True)
+adata.uns["between_waypoint_distances"] = pairwise_distances(
+    adata.obsm["X_emb"][solution.obs["is_waypoint"].values, :],
+    adata.obsm["X_emb"][solution.obs["is_waypoint"].values, :],
+    metric="euclidean",
+    n_jobs=-2,
+)
+np.fill_diagonal(adata.uns["between_waypoint_distances"], 0)
 
 print("\n>>> Calculating label centroids...", flush=True)
 emb_mat = adata.obsm["X_emb"]
@@ -40,12 +50,20 @@ for i, label in enumerate(labels):
 
 adata.uns["label_centroids"] = centroids
 
-print("\n>>> Calculating centroid distances...", flush=True)
+print("\n>>> Calculating distances to centroids...", flush=True)
 adata.obsm["centroid_distances"] = pairwise_distances(
     adata.obsm["X_emb"], centroids, metric="euclidean", n_jobs=-2
 )
+np.fill_diagonal(adata.obsm["centroid_distances"], 0)
+
+print("\n>>> Calculating distances between centroids...", flush=True)
+adata.uns["between_centroid_distances"] = pairwise_distances(
+    centroids, centroids, metric="euclidean", n_jobs=-2
+)
+np.fill_diagonal(adata.uns["between_centroid_distances"], 0)
 
 print("\n>>> Writing processed embedding...", flush=True)
+print(adata, flush=True)
 adata.write_h5ad(par["output"])
 print(f"Output dataset file: '{par['output']}'", flush=True)
 

--- a/src/data_processors/process_embedding/script.py
+++ b/src/data_processors/process_embedding/script.py
@@ -1,0 +1,52 @@
+import anndata as ad
+import numpy as np
+from sklearn.metrics import pairwise_distances
+
+## VIASH START
+par = {
+    "input_embedding": "resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/embedding.h5ad",
+    "input_solution": "resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/solution.h5ad",
+    "output_embedding": "processed_embedding.h5ad",
+}
+## VIASH END
+
+print("====== Embedding processor ======", flush=True)
+
+print("\n>>> Reading solution...", flush=True)
+solution = ad.read_h5ad(par["input_solution"])
+print(solution, flush=True)
+
+print("\n>>> Reading embedding...", flush=True)
+adata = ad.read_h5ad(par["input_embedding"])
+# Make sure cells have the same order
+adata = adata[solution.obs_names, :].copy()
+print(adata, flush=True)
+
+print("\n>>> Calculating waypoint distances...", flush=True)
+adata.obsm["waypoint_distances"] = pairwise_distances(
+    adata.obsm["X_emb"],
+    adata.obsm["X_emb"][solution.obs["is_waypoint"].values, :],
+    metric="euclidean",
+    n_jobs=-2,
+)
+
+print("\n>>> Calculating label centroids...", flush=True)
+emb_mat = adata.obsm["X_emb"]
+labels = np.unique(solution.obs["cell_type"])
+centroids = np.zeros((len(labels), emb_mat.shape[1]))
+for i, label in enumerate(labels):
+    is_label = solution.obs["cell_type"] == label
+    centroids[i, :] = np.mean(emb_mat[is_label, :], axis=0)
+
+adata.uns["label_centroids"] = centroids
+
+print("\n>>> Calculating centroid distances...", flush=True)
+adata.obsm["centroid_distances"] = pairwise_distances(
+    adata.obsm["X_emb"], centroids, metric="euclidean", n_jobs=-2
+)
+
+print("\n>>> Writing processed embedding...", flush=True)
+adata.write_h5ad(par["output"])
+print(f"Output dataset file: '{par['output']}'", flush=True)
+
+print("\n>>> Done!", flush=True)

--- a/src/methods/diffusion_map/script.R
+++ b/src/methods/diffusion_map/script.R
@@ -31,4 +31,5 @@ output <- anndata::AnnData(
   ),
   shape = input$shape
 )
+output$obs_names <- input$obs_names
 output$write_h5ad(par$output, compression = "gzip")

--- a/src/methods/lmds/script.R
+++ b/src/methods/lmds/script.R
@@ -33,4 +33,5 @@ output <- anndata::AnnData(
   ),
   shape = input$shape
 )
+output$obs_names <- input$obs_names
 output$write_h5ad(par$output, compression = "gzip")

--- a/src/methods/simlr/script.R
+++ b/src/methods/simlr/script.R
@@ -63,4 +63,5 @@ output <- anndata::AnnData(
   ),
   shape = input$shape
 )
+output$obs_names <- input$obs_names
 output$write_h5ad(par$output, compression = "gzip")

--- a/src/metrics/coranking/config.vsh.yaml
+++ b/src/metrics/coranking/config.vsh.yaml
@@ -103,7 +103,6 @@ engines:
     - type: r
       cran:
         - coRanking
-        - proxyC
 runners:
   - type: executable
   - type: nextflow

--- a/src/metrics/coranking/script.R
+++ b/src/metrics/coranking/script.R
@@ -14,8 +14,8 @@ input_solution <- anndata::read_h5ad(par[["input_solution"]])
 input_embedding <- anndata::read_h5ad(par[["input_embedding"]])
 
 # Get datasets
-dist_highdim <- input_solution$obsm[["waypoint_distances"]]
-dist_emb <- input_embedding$obsm[["waypoint_distances"]]
+dist_highdim <- input_solution$uns[["between_waypoint_distances"]]
+dist_emb <- input_embedding$uns[["between_waypoint_distances"]]
 
 if (any(is.na(dist_emb))) {
   continuity_at_k30 <- 0

--- a/src/metrics/coranking/script.R
+++ b/src/metrics/coranking/script.R
@@ -3,8 +3,8 @@ library(coRanking)
 
 ## VIASH START
 par <- list(
-  "input_embedding" = "resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/reduced.h5ad",
-  "input_solution" = "resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/test.h5ad",
+  "input_embedding" = "resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/processed_embedding.h5ad",
+  "input_solution" = "resources_test/task_dimensionality_reduction/cxg_mouse_pancreas_atlas/solution.h5ad",
   "output" = "score.h5ad"
 )
 ## VIASH END
@@ -14,10 +14,10 @@ input_solution <- anndata::read_h5ad(par[["input_solution"]])
 input_embedding <- anndata::read_h5ad(par[["input_embedding"]])
 
 # Get datasets
-high_dim <- input_solution$layers[["normalized"]]
-X_emb <- input_embedding$obsm[["X_emb"]]
+dist_highdim <- input_solution$obsm[["waypoint_distances"]]
+dist_emb <- input_embedding$obsm[["waypoint_distances"]]
 
-if (any(is.na(X_emb))) {
+if (any(is.na(dist_emb))) {
   continuity_at_k30 <- 0
   trustworthiness_at_k30 <- 0
   qnx_at_k30 <- 0
@@ -26,19 +26,6 @@ if (any(is.na(X_emb))) {
   qlocal <- 0
   qglobal <- 0
 } else {
-  message("Compute pairwise distances")
-  # TODO: computing a square distance matrix is problematic for large datasets!
-  # TODO: should we use a different distance metric for the high_dim?
-  # TODO: or should we subset to the HVG?
-  message("Compute high-dimensional distances")
-  dist_highdim <- proxyC::dist(
-    high_dim, method = "euclidean", diag = TRUE, drop0 = TRUE
-  )
-  message("Compute embedding distances")
-  dist_emb <- proxyC::dist(
-    X_emb, method = "euclidean", diag = TRUE, drop0 = TRUE
-  )
-
   message("Compute ranking matrices")
   rmat_highdim <- rankmatrix(dist_highdim, input = "dist")
   rmat_emb <- rankmatrix(dist_emb, input = "dist")

--- a/src/metrics/distance_correlation/config.vsh.yaml
+++ b/src/metrics/distance_correlation/config.vsh.yaml
@@ -5,13 +5,25 @@ __merge__: ../../api/comp_metric.yaml
 name: distance_correlation
 info:
   metrics:
-    - name: distance_correlation
-      label: Distance Correlation
-      summary: "Calculates the distance correlation by computing Spearman correlations between distances."
+    - name: waypoint_distance_correlation
+      label: Waypoint Distance Correlation
+      summary: "Calculates the distance correlation by computing Spearman correlations between distances to waypoint cells."
       description: |
         Calculates the distance correlation by computing Spearman correlations
-        between distances on the full (or processed) data matrix and the
-        dimensionally-reduced matrix."
+        between distances to waypoint cells on the full (or processed) data
+        matrix and the dimensionally-reduced matrix."
+      references:
+        doi: 10.1007/bf02289565
+      min: -1
+      max: 1
+      maximize: true
+    - name: centroid_distance_correlation
+      label: Centroid Distance Correlation
+      summary: "Calculates the distance correlation by computing Spearman correlations between distances to label centroids."
+      description: |
+        Calculates the distance correlation by computing Spearman correlations
+        between distances to label centroids on the full (or processed) data
+        matrix and the dimensionally-reduced matrix."
       references:
         doi: 10.1007/bf02289565
       min: -1

--- a/src/metrics/distance_correlation/config.vsh.yaml
+++ b/src/metrics/distance_correlation/config.vsh.yaml
@@ -11,9 +11,12 @@ info:
       description: |
         Calculates the distance correlation by computing Spearman correlations
         between distances to waypoint cells on the full (or processed) data
-        matrix and the dimensionally-reduced matrix."
+        matrix and the dimensionally-reduced matrix. Also known as the
+        cellstruct global single-cell (GS) score when using Pearson correlation.
       references:
-        doi: 10.1007/bf02289565
+        doi:
+          - 10.1101/2023.11.13.566337
+          - 10.1038/s42003-022-03628-x
       min: -1
       max: 1
       maximize: true
@@ -23,9 +26,11 @@ info:
       description: |
         Calculates the distance correlation by computing Spearman correlations
         between distances to label centroids on the full (or processed) data
-        matrix and the dimensionally-reduced matrix."
+        matrix and the dimensionally-reduced matrix. Also known as Point-Cluster
+        Distance (PCD) correlation.
       references:
-        doi: 10.1007/bf02289565
+        doi:
+          - 10.1038/s41467-023-37478-w
       min: -1
       max: 1
       maximize: true
@@ -34,10 +39,13 @@ info:
       summary: "Calculates the distance correlation by computing Spearman correlations between distances between label centroids."
       description: |
         Calculates the distance correlation by computing Spearman correlations
-        between distances between label centroids on the full (or processed) data
-        matrix and the dimensionally-reduced matrix."
+        between distances between label centroids on the full (or processed)
+        data matrix and the dimensionally-reduced matrix. Also known as the
+        cellstruct global cluster (GC) score when using Pearson correlation.
       references:
-        doi: 10.1007/bf02289565
+        doi:
+          - 10.1101/2023.11.13.566337
+          - 10.1038/s42003-022-03628-x
       min: -1
       max: 1
       maximize: true

--- a/src/metrics/distance_correlation/config.vsh.yaml
+++ b/src/metrics/distance_correlation/config.vsh.yaml
@@ -29,6 +29,18 @@ info:
       min: -1
       max: 1
       maximize: true
+    - name: label_distance_correlation
+      label: Label Distance Correlation
+      summary: "Calculates the distance correlation by computing Spearman correlations between distances between label centroids."
+      description: |
+        Calculates the distance correlation by computing Spearman correlations
+        between distances between label centroids on the full (or processed) data
+        matrix and the dimensionally-reduced matrix."
+      references:
+        doi: 10.1007/bf02289565
+      min: -1
+      max: 1
+      maximize: true
 
 # Script configuration
 resources:

--- a/src/metrics/distance_correlation/config.vsh.yaml
+++ b/src/metrics/distance_correlation/config.vsh.yaml
@@ -14,26 +14,11 @@ info:
         dimensionally-reduced matrix."
       references:
         doi: 10.1007/bf02289565
-      min: 0
-      max: "+.inf"
-      maximize: true
-    - name: distance_correlation_spectral
-      label: Distance Correlation Spectral
-      summary: "Spearman correlation between all pairwise diffusion distances in the original and dimension-reduced data."
-      description: |
-        Spearman correlation between all pairwise diffusion distances in the
-        original and dimension-reduced data.
-      references:
-        doi: 10.1016/j.acha.2006.04.006
-      min: 0
-      max: "+.inf"
+      min: -1
+      max: 1
       maximize: true
 
 # Script configuration
-arguments:
-  - name: "--spectral"
-    type: boolean_true
-    description: Calculate the spectral root mean squared error.
 resources:
   - type: python_script
     path: script.py
@@ -45,9 +30,7 @@ engines:
     setup:
       - type: python
         packages:
-          - umap-learn
           - scikit-learn
-          - pynndescent~=0.5.11 # See https://github.com/openproblems-bio/openproblems-v2/issues/266
 runners:
   - type: executable
   - type: nextflow

--- a/src/metrics/distance_correlation/script.py
+++ b/src/metrics/distance_correlation/script.py
@@ -9,7 +9,10 @@ par = {
 }
 ## VIASH END
 
-print(f"====== Distance correlation metrics (scipy v{scipy.__version__}) ======", flush=True)
+print(
+    f"====== Distance correlation metrics (scipy v{scipy.__version__}) ======",
+    flush=True,
+)
 
 print("\n>>> Reading solution...", flush=True)
 solution = ad.read_h5ad(par["input_solution"])
@@ -43,7 +46,11 @@ output = ad.AnnData(
         "dataset_id": solution.uns["dataset_id"],
         "normalization_id": solution.uns["normalization_id"],
         "method_id": embedding.uns["method_id"],
-        "metric_ids": ["waypoint_distance_correlation", "centroid_distance_correlation", "label_distance_correlation"],
+        "metric_ids": [
+            "waypoint_distance_correlation",
+            "centroid_distance_correlation",
+            "label_distance_correlation",
+        ],
         "metric_values": [waypoint_corr, centroid_corr, label_corr],
     }
 )

--- a/src/metrics/distance_correlation/script.py
+++ b/src/metrics/distance_correlation/script.py
@@ -31,14 +31,20 @@ emb_dists = embedding.obsm["centroid_distances"]
 centroid_corr = scipy.stats.spearmanr(high_dists, emb_dists, axis=None).correlation
 print(f"Centroid distance correlation: {centroid_corr}", flush=True)
 
+print("\n>>> Calculating label distance correlation..", flush=True)
+high_dists = solution.uns["between_centroid_distances"]
+emb_dists = embedding.uns["between_centroid_distances"]
+label_corr = scipy.stats.spearmanr(high_dists, emb_dists, axis=None).correlation
+print(f"Label distance correlation: {label_corr}", flush=True)
+
 print("\n>>> Creating output AnnData object...", flush=True)
 output = ad.AnnData(
     uns={
         "dataset_id": solution.uns["dataset_id"],
         "normalization_id": solution.uns["normalization_id"],
         "method_id": embedding.uns["method_id"],
-        "metric_ids": ["waypoint_distance_correlation", "centroid_distance_correlation"],
-        "metric_values": [waypoint_corr, centroid_corr],
+        "metric_ids": ["waypoint_distance_correlation", "centroid_distance_correlation", "label_distance_correlation"],
+        "metric_values": [waypoint_corr, centroid_corr, label_corr],
     }
 )
 print(output, flush=True)

--- a/src/metrics/distance_correlation/script.py
+++ b/src/metrics/distance_correlation/script.py
@@ -1,7 +1,5 @@
 import anndata as ad
-import scipy.spatial
-import scipy.stats
-import sklearn.decomposition
+import scipy
 
 ## VIASH START
 par = {
@@ -11,38 +9,36 @@ par = {
 }
 ## VIASH END
 
+print(f"====== Distance correlation metrics (scipy v{scipy.__version__}) ======", flush=True)
 
-def _distance_correlation(X, X_emb):
-    high_dimensional_distance_vector = scipy.spatial.distance.pdist(X)
-    low_dimensional_distance_vector = scipy.spatial.distance.pdist(X_emb)
-    corr = scipy.stats.spearmanr(
-        low_dimensional_distance_vector, high_dimensional_distance_vector
-    )
-    return corr
+print("\n>>> Reading solution...", flush=True)
+solution = ad.read_h5ad(par["input_solution"])
+print(solution, flush=True)
 
+print("\n>>> Reading embedding...", flush=True)
+embedding = ad.read_h5ad(par["input_embedding"])
+print(embedding, flush=True)
 
-print("Load data", flush=True)
-input_solution = ad.read_h5ad(par["input_solution"])
-input_embedding = ad.read_h5ad(par["input_embedding"])
+print("\n>>> Calculating distance correlation..", flush=True)
+high_dists = solution.obsm["waypoint_distances"]
+emb_dists = embedding.obsm["waypoint_distances"]
+dist_corr = scipy.stats.spearmanr(high_dists, emb_dists, axis=None).correlation
+print(f"Distance correlation: {dist_corr}", flush=True)
 
-high_dim = input_solution.layers["normalized"]
-X_emb = input_embedding.obsm["X_emb"]
-
-print("Compute NNLS residual after SVD", flush=True)
-n_svd = 500
-svd_emb = sklearn.decomposition.TruncatedSVD(n_svd).fit_transform(high_dim)
-dist_corr = _distance_correlation(svd_emb, X_emb).correlation
-
-print("Create output AnnData object", flush=True)
+print("\n>>> Creating output AnnData object...", flush=True)
 output = ad.AnnData(
     uns={
-        "dataset_id": input_solution.uns["dataset_id"],
-        "normalization_id": input_solution.uns["normalization_id"],
-        "method_id": input_embedding.uns["method_id"],
+        "dataset_id": solution.uns["dataset_id"],
+        "normalization_id": solution.uns["normalization_id"],
+        "method_id": embedding.uns["method_id"],
         "metric_ids": ["distance_correlation"],
         "metric_values": [dist_corr],
     }
 )
+print(output, flush=True)
 
-print("Write data to file", flush=True)
+print("\n>>> Writing output file...", flush=True)
 output.write_h5ad(par["output"], compression="gzip")
+print(f"Output file: '{par['output']}'", flush=True)
+
+print("\n>>> Done!", flush=True)

--- a/src/metrics/distance_correlation/script.py
+++ b/src/metrics/distance_correlation/script.py
@@ -19,11 +19,17 @@ print("\n>>> Reading embedding...", flush=True)
 embedding = ad.read_h5ad(par["input_embedding"])
 print(embedding, flush=True)
 
-print("\n>>> Calculating distance correlation..", flush=True)
+print("\n>>> Calculating waypoint distance correlation..", flush=True)
 high_dists = solution.obsm["waypoint_distances"]
 emb_dists = embedding.obsm["waypoint_distances"]
-dist_corr = scipy.stats.spearmanr(high_dists, emb_dists, axis=None).correlation
-print(f"Distance correlation: {dist_corr}", flush=True)
+waypoint_corr = scipy.stats.spearmanr(high_dists, emb_dists, axis=None).correlation
+print(f"Waypoint distance correlation: {waypoint_corr}", flush=True)
+
+print("\n>>> Calculating centroid distance correlation..", flush=True)
+high_dists = solution.obsm["centroid_distances"]
+emb_dists = embedding.obsm["centroid_distances"]
+centroid_corr = scipy.stats.spearmanr(high_dists, emb_dists, axis=None).correlation
+print(f"Centroid distance correlation: {centroid_corr}", flush=True)
 
 print("\n>>> Creating output AnnData object...", flush=True)
 output = ad.AnnData(
@@ -31,8 +37,8 @@ output = ad.AnnData(
         "dataset_id": solution.uns["dataset_id"],
         "normalization_id": solution.uns["normalization_id"],
         "method_id": embedding.uns["method_id"],
-        "metric_ids": ["distance_correlation"],
-        "metric_values": [dist_corr],
+        "metric_ids": ["waypoint_distance_correlation", "centroid_distance_correlation"],
+        "metric_values": [waypoint_corr, centroid_corr],
     }
 )
 print(output, flush=True)

--- a/src/metrics/spectral_distance_correlation/config.vsh.yaml
+++ b/src/metrics/spectral_distance_correlation/config.vsh.yaml
@@ -1,0 +1,43 @@
+# Base component API configuration
+__merge__: ../../api/comp_metric.yaml
+
+# Component configuration
+name: spectral_distance_correlation
+info:
+  metrics:
+    - name: spectral_distance_correlation
+      label: Spectral Distance Correlation
+      summary: "Spearman correlation between all pairwise diffusion distances in the original and dimension-reduced data."
+      description: |
+        Spearman correlation between all pairwise diffusion distances in the
+        original and dimension-reduced data.
+      references:
+        doi: 10.1016/j.acha.2006.04.006
+      min: -1
+      max: 1
+      maximize: true
+
+# Script configuration
+arguments:
+  - name: "--spectral"
+    type: boolean_true
+    description: Calculate the spectral root mean squared error.
+resources:
+  - type: python_script
+    path: script.py
+
+# Platform configuration
+engines:
+  - type: docker
+    image: openproblems/base_python:1.0.0
+    setup:
+      - type: python
+        packages:
+          - umap-learn
+          - scikit-learn
+          - pynndescent~=0.5.11 # See https://github.com/openproblems-bio/openproblems-v2/issues/266
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: [midtime, highmem, midcpu]

--- a/src/metrics/trustworthiness/config.vsh.yaml
+++ b/src/metrics/trustworthiness/config.vsh.yaml
@@ -3,6 +3,9 @@ __merge__: ../../api/comp_metric.yaml
 
 # Component configuration
 name: "trustworthiness"
+# Disabled due to being calculated as part of co-ranking metrics. May be removed
+# in the future.
+status: disabled
 info:
   metrics:
     - name: trustworthiness

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -82,6 +82,7 @@ dependencies:
   - name: metrics/coranking
   - name: metrics/density_preservation
   - name: metrics/distance_correlation
+  - name: metrics/spectral_distance_correlation
   - name: metrics/trustworthiness
 
 runners:

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -75,6 +75,8 @@ dependencies:
   - name: methods/simlr
   - name: methods/tsne
   - name: methods/umap
+  # Embedding processors
+  - name: data_processors/process_embedding
   # Metrics
   - name: metrics/clustering_performance
   - name: metrics/coranking

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -31,6 +31,7 @@ metrics = [
   coranking,
   density_preservation,
   distance_correlation,
+  spectral_distance_correlation,
   trustworthiness
 ]
 

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -31,8 +31,8 @@ metrics = [
   coranking,
   density_preservation,
   distance_correlation,
-  spectral_distance_correlation,
-  trustworthiness
+  spectral_distance_correlation
+  // trustworthiness
 ]
 
 workflow run_wf {

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -105,6 +105,14 @@ workflow run_wf {
       }
     )
 
+    // process output embeddings
+    | process_embedding.run(
+      fromState: [ input_embedding: "method_output", input_solution: "input_solution" ],
+      toState: [
+        processed_output: "output"
+      ]
+    )
+
     // run all metrics
     | runEach(
       components: metrics,
@@ -114,7 +122,7 @@ workflow run_wf {
       // use 'fromState' to fetch the arguments the component requires from the overall state
       fromState: [
         input_solution: "input_solution",
-        input_embedding: "method_output"
+        input_embedding: "processed_output"
       ],
       // use 'toState' to publish that component's outputs to the overall state
       toState: { id, output, state, comp ->


### PR DESCRIPTION
## Describe your changes

- Add calculation of distances to/between waypoints and label centroids to dataset pre-processing
- Add a post-processing component that calculates distances in the embedding space
- Modify co-ranking metrics to use pre-computed distances
- Modify distance correlation metrics to use pre-computed distances
- Add to centroid and between label distance correlation scores
- Move spectral distance correlation to a separate component
- Update documentation for distance correlation metrics
- Disable the trustworthiness metric as it is calculated as part of the co-ranking metrics

Fixes #7 

## Checklist before requesting a review

- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [x] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI Tests succeed and look good!