### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/random_features/config.vsh.yaml
+++ b/src/control_methods/random_features/config.vsh.yaml
@@ -19,7 +19,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/spectral_features/config.vsh.yaml
+++ b/src/control_methods/spectral_features/config.vsh.yaml
@@ -32,7 +32,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/control_methods/true_features/config.vsh.yaml
+++ b/src/control_methods/true_features/config.vsh.yaml
@@ -19,7 +19,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/data_processors/process_dataset/config.vsh.yaml
+++ b/src/data_processors/process_dataset/config.vsh.yaml
@@ -13,7 +13,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/data_processors/process_embedding/config.vsh.yaml
+++ b/src/data_processors/process_embedding/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/methods/densmap/config.vsh.yaml
+++ b/src/methods/densmap/config.vsh.yaml
@@ -38,7 +38,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/methods/diffusion_map/config.vsh.yaml
+++ b/src/methods/diffusion_map/config.vsh.yaml
@@ -27,7 +27,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: destiny

--- a/src/methods/ivis/config.vsh.yaml
+++ b/src/methods/ivis/config.vsh.yaml
@@ -40,7 +40,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/methods/lmds/config.vsh.yaml
+++ b/src/methods/lmds/config.vsh.yaml
@@ -52,7 +52,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran:

--- a/src/methods/neuralee/config.vsh.yaml
+++ b/src/methods/neuralee/config.vsh.yaml
@@ -49,7 +49,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/methods/pca/config.vsh.yaml
+++ b/src/methods/pca/config.vsh.yaml
@@ -36,7 +36,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: scanpy

--- a/src/methods/phate/config.vsh.yaml
+++ b/src/methods/phate/config.vsh.yaml
@@ -51,7 +51,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/methods/pymde/config.vsh.yaml
+++ b/src/methods/pymde/config.vsh.yaml
@@ -43,7 +43,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/methods/simlr/config.vsh.yaml
+++ b/src/methods/simlr/config.vsh.yaml
@@ -59,7 +59,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc:

--- a/src/methods/tsne/config.vsh.yaml
+++ b/src/methods/tsne/config.vsh.yaml
@@ -51,7 +51,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: apt
         packages:

--- a/src/methods/umap/config.vsh.yaml
+++ b/src/methods/umap/config.vsh.yaml
@@ -44,7 +44,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/metrics/clustering_performance/config.vsh.yaml
+++ b/src/metrics/clustering_performance/config.vsh.yaml
@@ -69,7 +69,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: [scikit-learn, scanpy, leidenalg]

--- a/src/metrics/coranking/config.vsh.yaml
+++ b/src/metrics/coranking/config.vsh.yaml
@@ -98,7 +98,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
     - type: r
       cran:

--- a/src/metrics/density_preservation/config.vsh.yaml
+++ b/src/metrics/density_preservation/config.vsh.yaml
@@ -34,7 +34,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/metrics/distance_correlation/config.vsh.yaml
+++ b/src/metrics/distance_correlation/config.vsh.yaml
@@ -58,7 +58,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/metrics/spectral_distance_correlation/config.vsh.yaml
+++ b/src/metrics/spectral_distance_correlation/config.vsh.yaml
@@ -29,7 +29,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/metrics/trustworthiness/config.vsh.yaml
+++ b/src/metrics/trustworthiness/config.vsh.yaml
@@ -29,7 +29,7 @@ resources:
 # Platform configuration
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.